### PR TITLE
Remove nixpacks.toml breaking Railway build

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,2 +1,0 @@
-[phases.setup]
-nixPkgs = ["nodejs_24", "npm-10_x", "openssl"]


### PR DESCRIPTION
The nixpacks.toml requests nodejs_24 which doesn't exist in Nix. Removing it so Railway uses its default Node 22.